### PR TITLE
Switch to gymnasium

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @h-vetinari @jkterry1 @pseudo-rnd-thoughts @thewchan
+* @h-vetinari @pseudo-rnd-thoughts @thewchan

--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
-About gym
-=========
+About gymnasium
+===============
 
-Home: https://github.com/openai/gym
+Home: https://gymnasium.farama.org/
 
 Package license: MIT
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gymnasium-feedstock/blob/main/LICENSE.txt)
 
-Summary: The OpenAI Gym: A toolkit for developing and comparing your reinforcement learning agents.
+Summary: A standard API for reinforcement learning and a diverse set of reference environments (formerly Gym)
 
-Development: https://github.com/openai/gym
-
-Documentation: https://gym.openai.com/docs/
-
-The OpenAI Gym: A toolkit for developing and comparing your reinforcement learning agents.
+Development: https://github.com/Farama-Foundation/Gymnasium
 
 Current build status
 ====================
@@ -129,59 +125,59 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gym-green.svg)](https://anaconda.org/conda-forge/gym) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gym.svg)](https://anaconda.org/conda-forge/gym) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gym.svg)](https://anaconda.org/conda-forge/gym) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gym.svg)](https://anaconda.org/conda-forge/gym) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gym--all-green.svg)](https://anaconda.org/conda-forge/gym-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gym-all.svg)](https://anaconda.org/conda-forge/gym-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gym-all.svg)](https://anaconda.org/conda-forge/gym-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gym-all.svg)](https://anaconda.org/conda-forge/gym-all) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gym--box2d-green.svg)](https://anaconda.org/conda-forge/gym-box2d) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gym-box2d.svg)](https://anaconda.org/conda-forge/gym-box2d) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gym-box2d.svg)](https://anaconda.org/conda-forge/gym-box2d) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gym-box2d.svg)](https://anaconda.org/conda-forge/gym-box2d) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gym--classic_control-green.svg)](https://anaconda.org/conda-forge/gym-classic_control) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gym-classic_control.svg)](https://anaconda.org/conda-forge/gym-classic_control) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gym-classic_control.svg)](https://anaconda.org/conda-forge/gym-classic_control) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gym-classic_control.svg)](https://anaconda.org/conda-forge/gym-classic_control) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gym--mujoco-green.svg)](https://anaconda.org/conda-forge/gym-mujoco) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gym-mujoco.svg)](https://anaconda.org/conda-forge/gym-mujoco) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gym-mujoco.svg)](https://anaconda.org/conda-forge/gym-mujoco) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gym-mujoco.svg)](https://anaconda.org/conda-forge/gym-mujoco) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gym--other-green.svg)](https://anaconda.org/conda-forge/gym-other) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gym-other.svg)](https://anaconda.org/conda-forge/gym-other) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gym-other.svg)](https://anaconda.org/conda-forge/gym-other) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gym-other.svg)](https://anaconda.org/conda-forge/gym-other) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gym--toy_text-green.svg)](https://anaconda.org/conda-forge/gym-toy_text) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gym-toy_text.svg)](https://anaconda.org/conda-forge/gym-toy_text) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gym-toy_text.svg)](https://anaconda.org/conda-forge/gym-toy_text) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gym-toy_text.svg)](https://anaconda.org/conda-forge/gym-toy_text) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium-green.svg)](https://anaconda.org/conda-forge/gymnasium) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium.svg)](https://anaconda.org/conda-forge/gymnasium) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium.svg)](https://anaconda.org/conda-forge/gymnasium) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium.svg)](https://anaconda.org/conda-forge/gymnasium) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--all-green.svg)](https://anaconda.org/conda-forge/gymnasium-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-all.svg)](https://anaconda.org/conda-forge/gymnasium-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-all.svg)](https://anaconda.org/conda-forge/gymnasium-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-all.svg)](https://anaconda.org/conda-forge/gymnasium-all) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--box2d-green.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-box2d.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-box2d.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-box2d.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--classic_control-green.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-classic_control.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-classic_control.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-classic_control.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--mujoco-green.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-mujoco.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-mujoco.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-mujoco.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--other-green.svg)](https://anaconda.org/conda-forge/gymnasium-other) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-other.svg)](https://anaconda.org/conda-forge/gymnasium-other) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-other.svg)](https://anaconda.org/conda-forge/gymnasium-other) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-other.svg)](https://anaconda.org/conda-forge/gymnasium-other) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--toy_text-green.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-toy_text.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-toy_text.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-toy_text.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) |
 
-Installing gym
-==============
+Installing gymnasium
+====================
 
-Installing `gym` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `gymnasium` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `gym, gym-all, gym-box2d, gym-classic_control, gym-mujoco, gym-other, gym-toy_text` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `gymnasium, gymnasium-all, gymnasium-box2d, gymnasium-classic_control, gymnasium-mujoco, gymnasium-other, gymnasium-toy_text` can be installed with `conda`:
 
 ```
-conda install gym gym-all gym-box2d gym-classic_control gym-mujoco gym-other gym-toy_text
-```
-
-or with `mamba`:
-
-```
-mamba install gym gym-all gym-box2d gym-classic_control gym-mujoco gym-other gym-toy_text
-```
-
-It is possible to list all of the versions of `gym` available on your platform with `conda`:
-
-```
-conda search gym --channel conda-forge
+conda install gymnasium gymnasium-all gymnasium-box2d gymnasium-classic_control gymnasium-mujoco gymnasium-other gymnasium-toy_text
 ```
 
 or with `mamba`:
 
 ```
-mamba search gym --channel conda-forge
+mamba install gymnasium gymnasium-all gymnasium-box2d gymnasium-classic_control gymnasium-mujoco gymnasium-other gymnasium-toy_text
+```
+
+It is possible to list all of the versions of `gymnasium` available on your platform with `conda`:
+
+```
+conda search gymnasium --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search gymnasium --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search gym --channel conda-forge
+mamba repoquery search gymnasium --channel conda-forge
 
-# List packages depending on `gym`:
-mamba repoquery whoneeds gym --channel conda-forge
+# List packages depending on `gymnasium`:
+mamba repoquery whoneeds gymnasium --channel conda-forge
 
-# List dependencies of `gym`:
-mamba repoquery depends gym --channel conda-forge
+# List dependencies of `gymnasium`:
+mamba repoquery depends gymnasium --channel conda-forge
 ```
 
 
@@ -226,17 +222,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating gym-feedstock
-======================
+Updating gymnasium-feedstock
+============================
 
-If you would like to improve the gym recipe or build a new
+If you would like to improve the gymnasium recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/gym-feedstock are
+Note that all branches in the conda-forge/gymnasium-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ Feedstock Maintainers
 =====================
 
 * [@h-vetinari](https://github.com/h-vetinari/)
-* [@jkterry1](https://github.com/jkterry1/)
 * [@pseudo-rnd-thoughts](https://github.com/pseudo-rnd-thoughts/)
 * [@thewchan](https://github.com/thewchan/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,10 @@ outputs:
     build:
       script: {{ PYTHON }} -m pip install . -vv --no-deps
     requirements:
+      build:
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - numpy                                  # [build_platform != target_platform]
       host:
         - python
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ source:
   sha256: 4b09589ae94885b6ad2864d4fb75ec3b0e97a2ded8704e4683e114d7762e21f5
 
 build:
+  # note: gymnasium 0.26.3 *_0 has been published already; when we republish
+  # 0.26.3 with all the optional builds, the build number needs to be >0!
   number: 0
 
 # Need these up here for conda-smithy to handle them properly.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -188,7 +188,6 @@ about:
 extra:
   recipe-maintainers:
     - h-vetinari
-    - jkterry1
     - pseudo-rnd-thoughts
     - thewchan
   feedstock-name: gymnasium

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
 {% set version = "0.26.1" %}
 
 package:
-  name: gym
+  name: gymnasium-split
   version: {{ version }}
 
 source:
-  url: https://github.com/openai/gym/archive/refs/tags/{{ version }}.tar.gz
-  sha256: bff4d02892e73091b40bc82d67f0007f46926cb7ab91ffff3b048395ec321a83
+  url: https://github.com/Farama-Foundation/Gymnasium/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 4b09589ae94885b6ad2864d4fb75ec3b0e97a2ded8704e4683e114d7762e21f5
 
 build:
   number: 0
@@ -26,7 +26,7 @@ requirements:
     - python
 
 outputs:
-  - name: gym
+  - name: gymnasium
     build:
       script: {{ PYTHON }} -m pip install . -vv --no-deps
     requirements:
@@ -38,28 +38,28 @@ outputs:
       run:
         - python
         - cloudpickle >=1.2.0
-        - gym-notices
+        - gymnasium-notices
         - numpy
         - importlib_metadata >=4.8.1  # [py<=39]
     test:
       imports:
-        - gym
+        - gymnasium
 
-  - name: gym-all
+  - name: gymnasium-all
     requirements:
       host:
         - python
       run:
         - python
         # see below
-        # - {{ pin_subpackage('gym-atari', exact=True) }}
-        - {{ pin_subpackage('gym-box2d', exact=True) }}
-        - {{ pin_subpackage('gym-classic_control', exact=True) }}
-        - {{ pin_subpackage('gym-mujoco', exact=True) }}
+        # - {{ pin_subpackage('gymnasium-atari', exact=True) }}
+        - {{ pin_subpackage('gymnasium-box2d', exact=True) }}
+        - {{ pin_subpackage('gymnasium-classic_control', exact=True) }}
+        - {{ pin_subpackage('gymnasium-mujoco', exact=True) }}
         # see below
-        # - {{ pin_subpackage('gym-mujoco_py', exact=True) }}
-        - {{ pin_subpackage('gym-toy_text', exact=True) }}
-        - {{ pin_subpackage('gym-other', exact=True) }}
+        # - {{ pin_subpackage('gymnasium-mujoco_py', exact=True) }}
+        - {{ pin_subpackage('gymnasium-toy_text', exact=True) }}
+        - {{ pin_subpackage('gymnasium-other', exact=True) }}
     test:
       source_files:
         - tests/
@@ -72,62 +72,62 @@ outputs:
         # TODO: figure out segfaults
         # - pytest -v tests/
 
-  - name: gym-atari
+  - name: gymnasium-atari
     build:
       # needs some as-yet unsolved packaging shenanigans
-      # to actually install gym.envs.atari
+      # to actually install gymnasium.envs.atari
       skip: true
     requirements:
       host:
         - python
       run:
         - python
-        - {{ pin_subpackage('gym', exact=True) }}
+        - {{ pin_subpackage('gymnasium', exact=True) }}
         - ale-py >=0.8.0,<0.9
     test:
       imports:
-        - gym.envs.atari
+        - gymnasium.envs.atari
 
-  - name: gym-box2d
+  - name: gymnasium-box2d
     requirements:
       host:
         - python
         - swig ==4.*
       run:
         - python
-        - {{ pin_subpackage('gym', exact=True) }}
+        - {{ pin_subpackage('gymnasium', exact=True) }}
         - box2d-py ==2.3.*
         - pygame ==2.1.*
     test:
       imports:
-        - gym.envs.box2d
+        - gymnasium.envs.box2d
 
-  - name: gym-classic_control
+  - name: gymnasium-classic_control
     requirements:
       host:
         - python
       run:
         - python
-        - {{ pin_subpackage('gym', exact=True) }}
+        - {{ pin_subpackage('gymnasium', exact=True) }}
         - pygame ==2.1.*
     test:
       imports:
-        - gym.envs.classic_control
+        - gymnasium.envs.classic_control
 
-  - name: gym-mujoco
+  - name: gymnasium-mujoco
     requirements:
       host:
         - python
       run:
         - python
-        - {{ pin_subpackage('gym', exact=True) }}
+        - {{ pin_subpackage('gymnasium', exact=True) }}
         - mujoco-python ==2.2.0
         - imageio >=2.14.1
     test:
       imports:
-        - gym.envs.mujoco
+        - gymnasium.envs.mujoco
 
-  - name: gym-mujoco_py
+  - name: gymnasium-mujoco_py
     build:
       # we currently don't have https://github.com/openai/mujoco-py
       # in conda-forge, and it'll be replaced by mujoco anyway
@@ -137,49 +137,47 @@ outputs:
         - python
       run:
         - python
-        - {{ pin_subpackage('gym', exact=True) }}
+        - {{ pin_subpackage('gymnasium', exact=True) }}
         - mujoco-py >=2.1,<2.2
         - imageio >=2.14.1
     test:
       imports:
-        - gym.envs.mujoco
+        - gymnasium.envs.mujoco
 
-  - name: gym-toy_text
+  - name: gymnasium-toy_text
     requirements:
       host:
         - python
       run:
         - python
-        - {{ pin_subpackage('gym', exact=True) }}
+        - {{ pin_subpackage('gymnasium', exact=True) }}
         - pygame ==2.1.*
     test:
       imports:
-        - gym.envs.toy_text
+        - gymnasium.envs.toy_text
 
-  - name: gym-other
+  - name: gymnasium-other
     requirements:
       host:
         - python
       run:
         - python
-        - {{ pin_subpackage('gym', exact=True) }}
+        - {{ pin_subpackage('gymnasium', exact=True) }}
         - lz4 >=3.1.0
         - matplotlib >=3.0
         - moviepy >=1.0
         - py-opencv >=3.0
     test:
       imports:
-        # There are no tests in the source code for gym-other
+        # There are no tests in the source code for gymnasium-other
 
 about:
-  home: https://github.com/openai/gym
+  home: https://gymnasium.farama.org/
   license: MIT
   license_family: MIT
   license_file: LICENSE.md
-  summary: 'The OpenAI Gym: A toolkit for developing and comparing your reinforcement learning agents.'
-  description: 'The OpenAI Gym: A toolkit for developing and comparing your reinforcement learning agents.'
-  doc_url: https://gym.openai.com/docs/
-  dev_url: https://github.com/openai/gym
+  summary: A standard API for reinforcement learning and a diverse set of reference environments (formerly Gym)
+  dev_url: https://github.com/Farama-Foundation/Gymnasium
 
 extra:
   recipe-maintainers:
@@ -187,3 +185,4 @@ extra:
     - jkterry1
     - pseudo-rnd-thoughts
     - thewchan
+  feedstock-name: gymnasium


### PR DESCRIPTION
Follow-up to #9 (after importing the history from gym-feedstock).

Originally I thought we should keep publishing all `gym-*` packages as thin compatibility wrappers around their `gymnasium-*` equivalents, but since the imports changed (even just from `import gym` to `import gymnasium as gym`), this would probably break more code than it would help.

~Based on #9, will be rebased once that's in.~

Closes #10 