### PR TITLE
Add testing to CI

### DIFF
--- a/recipe/custom_tests/test_1.py
+++ b/recipe/custom_tests/test_1.py
@@ -1,0 +1,14 @@
+
+import gymnasium as gym
+
+env = gym.make("CartPole-v1")
+observation, info = env.reset(seed=42)
+
+for _ in range(1000):
+   action = env.action_space.sample()  # this is where you would insert your policy
+   observation, reward, terminated, truncated, info = env.step(action)
+
+   if terminated or truncated:
+      observation, info = env.reset()
+
+env.close()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,16 +67,18 @@ outputs:
         - {{ pin_subpackage('gymnasium-toy_text', exact=True) }}
         - {{ pin_subpackage('gymnasium-other', exact=True) }}
     test:
-      source_files:
-        - tests/
+#      source_files:
+#        - tests/
+      files:
+        - custom_tests/
       requires:
         - mock
         - pytest
         - pip
       commands:
         - pip check
-        # TODO: figure out segfaults
-        - pytest -v tests/test_core.py tests/envs/test_compatibility.py tests/spaces
+#        - pytest -v tests/test_core.py tests/envs/test_compatibility.py tests/spaces
+        - pytest custom_tests/test_1.py
 
   - name: gymnasium-atari
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ outputs:
       commands:
         - pip check
         # TODO: figure out segfaults
-        # - pytest -v tests/
+        - pytest -v tests/test_core.py
 
   - name: gymnasium-atari
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ outputs:
       commands:
         - pip check
         # TODO: figure out segfaults
-        - pytest -v tests/test_core.py
+        - pytest -v tests/test_core.py tests/spaces
 
   - name: gymnasium-atari
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ outputs:
       commands:
         - pip check
         # TODO: figure out segfaults
-        - pytest -v tests/test_core.py tests/envs/test_compatibility.py tests/envs/test_envs.py tests/spaces
+        - pytest -v tests/test_core.py tests/envs/test_compatibility.py tests/spaces
 
   - name: gymnasium-atari
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ outputs:
       commands:
         - pip check
         # TODO: figure out segfaults
-        - pytest -v tests/test_core.py tests/spaces
+        - pytest -v tests/test_core.py tests/envs/test_compatibility.py tests/envs/test_envs.py tests/spaces
 
   - name: gymnasium-atari
     build:


### PR DESCRIPTION
Previously in https://github.com/conda-forge/gymnasium-feedstock/pull/22, @h-vetinari added testing through running the whole gymnasium testing ci. However, this caused a segfault for unknown reasons.

In this PR, I aim to sequentially add testing to try and identify the package or cause of the issue (my suspicion is pygame, moviepy or jax is the issue)

Tests added
1. `test_core.py` - this is the most basic test that checks the base API
2. `spaces/*` - this is testing for all of the gymnasium spaces, this should not import external modules (except numpy)