### PR TITLE
add outputs for `gymnasium-{jax,torch}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--atari-green.svg)](https://anaconda.org/conda-forge/gymnasium-atari) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-atari.svg)](https://anaconda.org/conda-forge/gymnasium-atari) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-atari.svg)](https://anaconda.org/conda-forge/gymnasium-atari) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-atari.svg)](https://anaconda.org/conda-forge/gymnasium-atari) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--box2d-green.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-box2d.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-box2d.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-box2d.svg)](https://anaconda.org/conda-forge/gymnasium-box2d) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--classic__control-green.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-classic_control.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-classic_control.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-classic_control.svg)](https://anaconda.org/conda-forge/gymnasium-classic_control) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--jax-green.svg)](https://anaconda.org/conda-forge/gymnasium-jax) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-jax.svg)](https://anaconda.org/conda-forge/gymnasium-jax) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-jax.svg)](https://anaconda.org/conda-forge/gymnasium-jax) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-jax.svg)](https://anaconda.org/conda-forge/gymnasium-jax) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--mujoco-green.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-mujoco.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-mujoco.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-mujoco.svg)](https://anaconda.org/conda-forge/gymnasium-mujoco) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--other-green.svg)](https://anaconda.org/conda-forge/gymnasium-other) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-other.svg)](https://anaconda.org/conda-forge/gymnasium-other) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-other.svg)](https://anaconda.org/conda-forge/gymnasium-other) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-other.svg)](https://anaconda.org/conda-forge/gymnasium-other) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--torch-green.svg)](https://anaconda.org/conda-forge/gymnasium-torch) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-torch.svg)](https://anaconda.org/conda-forge/gymnasium-torch) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-torch.svg)](https://anaconda.org/conda-forge/gymnasium-torch) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-torch.svg)](https://anaconda.org/conda-forge/gymnasium-torch) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gymnasium--toy__text-green.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gymnasium-toy_text.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gymnasium-toy_text.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gymnasium-toy_text.svg)](https://anaconda.org/conda-forge/gymnasium-toy_text) |
 
 Installing gymnasium
@@ -228,16 +230,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `gymnasium, gymnasium-all, gymnasium-atari, gymnasium-box2d, gymnasium-classic_control, gymnasium-mujoco, gymnasium-other, gymnasium-toy_text` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `gymnasium, gymnasium-all, gymnasium-atari, gymnasium-box2d, gymnasium-classic_control, gymnasium-jax, gymnasium-mujoco, gymnasium-other, gymnasium-torch, gymnasium-toy_text` can be installed with `conda`:
 
 ```
-conda install gymnasium gymnasium-all gymnasium-atari gymnasium-box2d gymnasium-classic_control gymnasium-mujoco gymnasium-other gymnasium-toy_text
+conda install gymnasium gymnasium-all gymnasium-atari gymnasium-box2d gymnasium-classic_control gymnasium-jax gymnasium-mujoco gymnasium-other gymnasium-torch gymnasium-toy_text
 ```
 
 or with `mamba`:
 
 ```
-mamba install gymnasium gymnasium-all gymnasium-atari gymnasium-box2d gymnasium-classic_control gymnasium-mujoco gymnasium-other gymnasium-toy_text
+mamba install gymnasium gymnasium-all gymnasium-atari gymnasium-box2d gymnasium-classic_control gymnasium-jax gymnasium-mujoco gymnasium-other gymnasium-torch gymnasium-toy_text
 ```
 
 It is possible to list all of the versions of `gymnasium` available on your platform with `conda`:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
     - patches/0001-Fix-jax-0.6.0-regression-in-jax_to_numpy-and-jax_to_.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -59,6 +59,12 @@ outputs:
         - ${{ pin_subpackage('gymnasium-mujoco', exact=True) }}
         - ${{ pin_subpackage('gymnasium-toy_text', exact=True) }}
         - ${{ pin_subpackage('gymnasium-other', exact=True) }}
+        - if: not (win or ppc64le)
+          then:
+            - ${{ pin_subpackage('gymnasium-jax', exact=True) }}
+        - if: not ppc64le
+          then:
+            - ${{ pin_subpackage('gymnasium-torch', exact=True) }}
     tests:
       - python:
           pip_check: true
@@ -74,15 +80,10 @@ outputs:
             - scipy
             - dill
             - pip
-            - if: linux and not ppc64le
-              then:
-                - jax >=0.4
-                - flax >=0.5.0
-            - if: osx and match(python, "<3.13")
+            - if: osx
               then:
                 # flaky segfaults with newer jax on osx
                 - jax >=0.4,<0.5
-                - flax >=0.5.0
             - if: linux
               then: mesalib
             # Just for tests a newer version of mujoco is required
@@ -183,7 +184,8 @@ outputs:
           # see https://github.com/conda-forge/gymnasium-feedstock/pull/36#issuecomment-2124699477
           - if: unix
             then: export SDL_VIDEODRIVER="dummy"
-          - if: unix
+            # osx needs old jax to avoid segfaults, which is not available on 3.13
+          - if: unix and not (osx and match(python, ">=3.13"))
             then: pytest -v tests/ --durations=50 -k "not ($tests_to_skip)"
           - if: win
             then: pytest -v tests/ --durations=50 -k "not (%tests_to_skip%)"
@@ -232,6 +234,23 @@ outputs:
             - gymnasium.envs.classic_control
 
   - package:
+      name: gymnasium-jax
+    build:
+      # jax not available on ppc/win
+      skip: ppc64le or win
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - ${{ pin_subpackage('gymnasium', exact=True) }}
+        - flax >=0.5.0
+        - jax >=0.4.16
+    tests:
+      - script:
+          - echo "tested in gymnasium-all"
+
+  - package:
       name: gymnasium-mujoco
     requirements:
       host:
@@ -247,6 +266,22 @@ outputs:
             - gymnasium.envs.mujoco
 
   # gymnasium-mujoco_py intentionally not included due to license of https://github.com/openai/mujoco-py
+
+  - package:
+      name: gymnasium-torch
+    build:
+      # current pytorch not available on ppc
+      skip: ppc64le
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - ${{ pin_subpackage('gymnasium', exact=True) }}
+        - pytorch >=1.13
+    tests:
+      - script:
+          - echo "tested in gymnasium-all"
 
   - package:
       name: gymnasium-toy_text
@@ -274,8 +309,7 @@ outputs:
         - matplotlib >=3.0
         - moviepy >=1.0
         - py-opencv >=3.0
-        - if: unix and not ppc64le
-          then: pytorch >=1.0
+        - seaborn >=0.13
     tests:
       - script:
           - echo "no tests"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -57,8 +57,6 @@ outputs:
         - ${{ pin_subpackage('gymnasium-box2d', exact=True) }}
         - ${{ pin_subpackage('gymnasium-classic_control', exact=True) }}
         - ${{ pin_subpackage('gymnasium-mujoco', exact=True) }}
-        # see below
-        # - {{ pin_subpackage('gymnasium-mujoco_py', exact=True) }}
         - ${{ pin_subpackage('gymnasium-toy_text', exact=True) }}
         - ${{ pin_subpackage('gymnasium-other', exact=True) }}
     tests:
@@ -248,24 +246,7 @@ outputs:
           imports:
             - gymnasium.envs.mujoco
 
-  - package:
-      name: gymnasium-mujoco_py
-    build:
-      # we currently don't have https://github.com/openai/mujoco-py
-      # in conda-forge, and it'll be replaced by mujoco anyway
-      skip: true
-    requirements:
-      host:
-        - python
-      run:
-        - python
-        - ${{ pin_subpackage('gymnasium', exact=True) }}
-        - mujoco-py >=2.1,<2.2
-        - imageio >=2.14.1
-    tests:
-      - python:
-          imports:
-            - gymnasium.envs.mujoco
+  # gymnasium-mujoco_py intentionally not included due to license of https://github.com/openai/mujoco-py
 
   - package:
       name: gymnasium-toy_text


### PR DESCRIPTION
`gymnasium[jax]` has been [present](https://github.com/Farama-Foundation/Gymnasium/commit/34dfc9a7283defdb20d2be467666f235ddfb72fa) since 0.27, `gymnasium[torch]` [since](https://github.com/Farama-Foundation/Gymnasium/commit/286927923259dad30465b0bb190ae565b6f2668c) v1.0